### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.5
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - name: Setup Node
         uses: actions/setup-node@v2.5.0
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Make
         run: make
@@ -37,14 +37,14 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.5
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - name: Setup Node
         uses: actions/setup-node@v2.5.0
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Run semantic-release
         run: make semantic-release
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v2.8.0
         with:
           version: latest
           args: release --rm-dist

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,16 @@
 module go.einride.tech/protoc-gen-go-grpc-service-config
 
-go 1.16
+go 1.17
 
 require (
-	google.golang.org/grpc v1.42.0
+	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/golang/protobuf v1.5.0 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
-google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/compiler/protogen"
 )
 
@@ -116,7 +117,7 @@ func (p *plugin) validate(required bool) error {
 			conn, err := grpc.Dial(
 				addr,
 				grpc.WithDefaultServiceConfig(string(data)),
-				grpc.WithInsecure(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
 			)
 			if err != nil {


### PR DESCRIPTION
Migrate away from deprecated grpc.WithInsecure to fix broken build.
